### PR TITLE
Fix bug that becomes an invalid type when argument of attr macro is omitted

### DIFF
--- a/addon/data/index.js
+++ b/addon/data/index.js
@@ -1,4 +1,5 @@
 import DS from 'ember-data';
+import { decoratorWithParams } from '../utils/decorator-wrappers';
 import { decoratorWithKeyReflection } from '../utils/decorator-macros';
 
 /**
@@ -16,7 +17,9 @@ import { decoratorWithKeyReflection } from '../utils/decorator-macros';
  * @function
  * @param {String} [type] - Type of the attribute
  */
-export const attr = decoratorWithKeyReflection(DS.attr);
+export const attr = decoratorWithParams(function(target, key, desc, params) {
+  return DS.attr(...params);
+});
 
 /**
  * Decorator that turns the property into an Ember Data `hasMany` relationship

--- a/tests/unit/ds-macro-test.js
+++ b/tests/unit/ds-macro-test.js
@@ -13,6 +13,7 @@ test('DS macro', function(assert) {
   var Model = DS.Model.extend({
     @attr firstName: null,
     @attr({ defaultTo: 'blue' }) lastName: null,
+    @attr('number') age: null,
     @hasMany user: null,
     @belongsTo car: null
   });
@@ -24,11 +25,15 @@ test('DS macro', function(assert) {
   };
 
   var attributes = [];
-  Model.eachAttribute(function(attr) {
-    attributes.push(attr);
+  Model.eachAttribute(function(attr, meta) {
+    attributes.push({name: attr, type: meta.type});
   });
 
-  assert.deepEqual(attributes, ['firstName', 'lastName']);
+  assert.deepEqual(attributes, [
+    {name: 'firstName', type: undefined},
+    {name: 'lastName',  type: undefined},
+    {name: 'age',       type: 'number'}
+  ]);
 
   var relationships = [];
   Model.eachRelationship(function(attr) {


### PR DESCRIPTION
The `@attr` macro has the same type as the property name when the argument is omitted. Therefore, `pushPayload()` on the model causes an error.

``` js
import Model from 'ember-data/model';
import { attr } from 'ember-decorators/data';

export default Model.extend({
  @attr name: null
});
```

``` js
this.get('store').pushPayload({
  data: {
    type: 'user',
    id: 1,
    attributes: {
      name: 'ursm'
    }
  }
});
//=> Assertion Failed: Unable to find transform for 'name'
```

This patch is modified to handle arguments like normal `DS.attr()`.