### PR TITLE
feat(accessors): Allows usage of property accessors with the @computed decorator

### DIFF
--- a/addon/object/index.js
+++ b/addon/object/index.js
@@ -147,11 +147,25 @@ export const action = decorator(function(target, key, desc) {
  * @param {...String} propertyNames - List of property keys this computed is dependent on
  */
 export const computed = decoratorWithParams(function(target, key, desc, params) {
-  if (!desc.writable) {
-    throw new Error('ember-decorators does not support using getters and setters');
+  if (desc.value instanceof Ember.ComputedProperty) {
+    throw new Error(`ES6 property getters/setters only need to be decorated once, '${key}' was decorated on both the getter and the setter`);
   }
 
-  let value = extractValue(desc);
+  let value;
+
+  if (desc.writable === undefined) {
+    value = {
+      get: desc.get,
+      set: desc.set
+    };
+
+    // Unset the getter and setter so the descriptor just has a plain value
+    desc.get = undefined;
+    desc.set = undefined;
+  } else {
+    value = extractValue(desc);
+  }
+
   return computedMacro(...params, value);
 });
 

--- a/tests/unit/computed-test.js
+++ b/tests/unit/computed-test.js
@@ -78,20 +78,6 @@ test('only calls getter when dependent keys change', function(assert) {
   assert.equal(callCount, 1);
 });
 
-test('throws an error when attempting to use ES6 getter/setter syntax', function(assert) {
-  assert.throws(() => {
-    return {
-      first: 'rob',
-      last: 'jackson',
-
-      @computed('first', 'last')
-      set name(value) { return value; },
-
-      get name() { }
-    };
-  });
-});
-
 test('allows using ember-new-computed style get/set syntax', function(assert) {
   // not currently supported by Babel (waiting on confirmation from @wycats
   // before opening an issue)
@@ -266,3 +252,95 @@ test('attr.@each.{foo,bar} passes attr', function(assert) {
   get(obj, 'something');
   set(obj, 'something', 'something');
 });
+
+test('works with es6 class', function(assert) {
+  assert.expect(2);
+
+  class Foo {
+    constructor() {
+      this.first = 'rob';
+      this.last = 'jackson';
+    }
+
+    @computed('first', 'last')
+    fullName(first, last) {
+      assert.equal(first, 'rob');
+      assert.equal(last, 'jackson');
+    }
+  }
+
+  let obj = new Foo();
+  get(obj, 'fullName');
+});
+
+test('works with es6 class getter', function(assert) {
+  assert.expect(2);
+
+  class Foo {
+    constructor() {
+      this.first = 'rob';
+      this.last = 'jackson';
+    }
+
+    @computed('first', 'last')
+    get fullName() {
+      assert.equal(this.first, 'rob');
+      assert.equal(this.last, 'jackson');
+    }
+  }
+
+  let obj = new Foo();
+  get(obj, 'fullName');
+});
+
+test('works with es6 class setter', function(assert) {
+  assert.expect(1);
+
+  class Foo {
+    @computed
+    set fullName(name) {
+      assert.equal(name, 'rob jackson');
+    }
+  }
+
+  let obj = new Foo();
+  set(obj, 'fullName', 'rob jackson');
+});
+
+test('works with es6 class getter and setter', function(assert) {
+  assert.expect(3);
+
+  class Foo {
+    constructor() {
+      this.first = 'rob';
+      this.last = 'jackson';
+    }
+
+    @computed('first', 'last')
+    get fullName() {
+      assert.equal(this.first, 'rob');
+      assert.equal(this.last, 'jackson');
+    }
+
+    set fullName(name) {
+      assert.equal(name, 'rob jackson');
+    }
+  }
+
+  let obj = new Foo();
+  get(obj, 'fullName');
+  set(obj, 'fullName', 'rob jackson');
+});
+
+test('throws if the same property is decorated more than once', function(assert) {
+  assert.throws(() => {
+    // eslint-disable-next-line
+    class Foo {
+      @computed
+      get fullName() {}
+
+      @computed
+      set fullName(name) {}
+    }
+  });
+})


### PR DESCRIPTION
Supercedes #61 (thanks for updating the test @offirgolan! Copied them over here 😄)

Removes the guard that prevents users from using the `@computed` decorator on getters and setters. If the descriptor has a getter/setter, the decorator now passes the descriptor directly into the `computedMacro` helper. Not sure if we want to do it this way, or explicitly pull the `get` and `set` functions off the descriptor and create a new object, but this seemed to work pretty well for now.