### PR TITLE
optimization(computed): Use simple computed for accessors

### DIFF
--- a/tests/unit/computed-test.js
+++ b/tests/unit/computed-test.js
@@ -308,7 +308,7 @@ test('works with es6 class setter', function(assert) {
 });
 
 test('works with es6 class getter and setter', function(assert) {
-  assert.expect(3);
+  assert.expect(5);
 
   class Foo {
     constructor() {
@@ -324,6 +324,10 @@ test('works with es6 class getter and setter', function(assert) {
 
     set fullName(name) {
       assert.equal(name, 'rob jackson');
+
+      // Check `this` context to make sure function was bound properly
+      assert.equal(this.first, 'rob');
+      assert.equal(this.last, 'jackson');
     }
   }
 


### PR DESCRIPTION
Opening this partially for discussion. I realized while looking at #89 that using ES6 getters/setters, most of the benefits provided by `ember-macro-helpers` actually don't work at all and only incur extra overhead.

`ember-macro-helpers` relies on being able to have arbitrary function arity. Getters are passed the resolved values for their dependent keys, _or_ the values of previous computeds that have been composed together. Setters also resolve these values, and in both cases that extra data can't be used at all because arity for getter and setter functions is restricted (Trying to make a getter function with any arguments or a setter function with more/less than one is a syntax error in Chrome and a compiler error in Babel.)

I don't think we really have a choice about accepting this behavior which is why I'm proposing this optimization, but it does seem like it could be problematic that the same decorator has somewhat different behavior in different cases.