### PR TITLE
bugfix(actions): Eagerly collapse Ember.Object prototypes

### DIFF
--- a/addon/object/index.js
+++ b/addon/object/index.js
@@ -48,9 +48,18 @@ const { computed: emberComputed } = Ember;
  * @function
  */
 export const action = decorator(function(target, key, desc) {
-  const value = extractValue(desc);
+  let value = extractValue(desc);
 
   assert('The @action decorator must be applied to functions', typeof value === 'function');
+
+  // We must collapse the superclass prototype to make sure that the `actions`
+  // object will exist. Since collapsing doesn't generally happen until a class is
+  // instantiated, we have to do it manually.
+  let superClass = Object.getPrototypeOf(target.constructor);
+
+  if (superClass.hasOwnProperty('proto') && typeof superClass.proto === 'function') {
+    superClass.proto();
+  }
 
   if (!target.hasOwnProperty('actions')) {
     let parentActions = target.actions;

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -11,6 +11,9 @@ module.exports = function(defaults) {
       config: {
         excludes: ['utils/.*']
       }
+    },
+    'ember-cli-babel': {
+      includePolyfill: true
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
+    "ember-maybe-import-regenerator": "^0.1.6",
     "ember-native-dom-helpers": "^0.5.0",
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2129,7 +2129,7 @@ ember-cli-babel@^5.1.3, ember-cli-babel@^5.1.6:
     ember-cli-version-checker "^1.0.2"
     resolve "^1.1.2"
 
-ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.1.0:
+ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.1.0:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.4.1.tgz#785a1c24fe3250eb0776b1ab3cee857863b44542"
   dependencies:
@@ -2155,13 +2155,13 @@ ember-cli-broccoli-sane-watcher@^2.0.4:
     rsvp "^3.0.18"
     sane "^1.1.1"
 
-ember-cli-dependency-checker@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/ember-cli-dependency-checker/-/ember-cli-dependency-checker-2.0.1.tgz#e44cd2f8cdbf6a1043092de1ebfd62e7b8c00dd1"
+ember-cli-dependency-checker@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-dependency-checker/-/ember-cli-dependency-checker-1.4.0.tgz#2b13f977e1eea843fc1a21a001be6ca5d4ef1942"
   dependencies:
-    chalk "^1.1.3"
-    is-git-url "^1.0.0"
-    semver "^5.3.0"
+    chalk "^0.5.1"
+    is-git-url "^0.2.0"
+    semver "^4.1.0"
 
 ember-cli-esdoc@0.0.4:
   version "0.0.4"
@@ -2513,6 +2513,15 @@ ember-macro-helpers@^0.15.1:
     ember-cli-string-utils "^1.1.0"
     ember-cli-test-info "^1.0.0"
     ember-weakmap "^2.0.0"
+
+ember-maybe-import-regenerator@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/ember-maybe-import-regenerator/-/ember-maybe-import-regenerator-0.1.6.tgz#35d41828afa6d6a59bc0da3ce47f34c573d776ca"
+  dependencies:
+    broccoli-funnel "^1.0.1"
+    broccoli-merge-trees "^1.0.0"
+    ember-cli-babel "^6.0.0-beta.4"
+    regenerator-runtime "^0.9.5"
 
 ember-native-dom-helpers@^0.5.0:
   version "0.5.0"
@@ -3799,10 +3808,6 @@ is-fullwidth-code-point@^2.0.0:
 is-git-url@^0.2.0:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/is-git-url/-/is-git-url-0.2.3.tgz#445200d6fbd6da028fb5e01440d9afc93f3ccb64"
-
-is-git-url@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-git-url/-/is-git-url-1.0.0.tgz#53f684cd143285b52c3244b4e6f28253527af66b"
 
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
@@ -5121,6 +5126,10 @@ regenerator-runtime@^0.10.0:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
+regenerator-runtime@^0.9.5:
+  version "0.9.6"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz#d33eb95d0d2001a4be39659707c51b0cb71ce029"
+
 regenerator-transform@0.9.11:
   version "0.9.11"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.9.11.tgz#3a7d067520cb7b7176769eb5ff868691befe1283"
@@ -5339,7 +5348,7 @@ sax@^1.1.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
-semver@^4.3.1:
+semver@^4.1.0, semver@^4.3.1:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
 


### PR DESCRIPTION
Fixes #128 

Currently the `actions` objects of plain Ember objects written the old-fashioned way doesn't exist at class definition time, it only gets finalized once a class is instantiated. The construction flow can probably be updated to do the linking between the old class style and new class style, but this fix should tide us over (assuming it doesn't cause any nasty side-effects). It calls the `proto` method of the constructor if it exists, eagerly collapsing and creating the `actions` object.