### PR TITLE
docs: ES6 classes and RFC 176 module imports (#120)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ import Component from '@ember/component'
 import { action, computed } from 'ember-decorators/object';
 import { service } from 'ember-decorators/service';
 
-export default class extends Component {
+export default class ExampleComponent extends Component {
   @service foo
 
   @computed('someKey', 'otherKey')

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ export default Ember.Component.extend({
     var someKey = this.get('someKey');
     var otherKey = this.get('otherKey');
 
-    // do stuff
+    return `${someKey} - ${otherKey}`;
   }),
 
   actions: {
@@ -46,16 +46,16 @@ export default Ember.Component.extend({
 You replace it with this:
 
 ```javascript
-import Ember from 'ember'
+import Component from '@ember/component'
 import { action, computed } from 'ember-decorators/object';
 import { service } from 'ember-decorators/service';
 
-export default class MyComponent extends Ember.Component {
+export default class extends Component {
   @service foo
 
   @computed('someKey', 'otherKey')
   bar(someKey, otherKey) {
-    // do stuff
+    return `${someKey} - ${otherKey}`;
   }
 
   @action

--- a/addon/controller/index.js
+++ b/addon/controller/index.js
@@ -7,12 +7,12 @@ import { decoratorWithKeyReflection } from '../utils/decorator-macros';
  * Injects a controller into a Controller as the decorated property
  *
  *  ```javascript
- * import Ember from 'ember';
- * import { service } from 'ember-decorators/controller';
+ * import Controller from '@ember/controller';
+ * import { controller } from 'ember-decorators/controller';
  *
- * export default Ember.Controller.extend({
+ * export default class extends Controller {
  *   @controller application
- * });
+ * }
  * ```
  *
  * @function

--- a/addon/controller/index.js
+++ b/addon/controller/index.js
@@ -11,7 +11,7 @@ import { decoratorWithKeyReflection } from '../utils/decorator-macros';
  * import { controller } from 'ember-decorators/controller';
  *
  * export default class extends Controller {
- *   @controller application
+ *   @controller application;
  * }
  * ```
  *

--- a/addon/controller/index.js
+++ b/addon/controller/index.js
@@ -10,7 +10,7 @@ import { decoratorWithKeyReflection } from '../utils/decorator-macros';
  * import Controller from '@ember/controller';
  * import { controller } from 'ember-decorators/controller';
  *
- * export default class extends Controller {
+ * export default class IndexController extends Controller {
  *   @controller application;
  * }
  * ```

--- a/addon/data/index.js
+++ b/addon/data/index.js
@@ -9,9 +9,9 @@ import { decoratorWithKeyReflection } from '../utils/decorator-macros';
  * import Model from 'ember-data/model';
  * import { attr } from 'ember-decorators/data';
  *
- * export default class extends Model {
- *   @attr firstName;
- * }
+ * export default Model.extend({
+ *   @attr firstName: null
+ * });
  * ```
  *
  * @function
@@ -28,9 +28,9 @@ export const attr = decoratorWithParams(function(target, key, desc, params) {
  * import Model from 'ember-data/model';
  * import { hasMany } from 'ember-decorators/data';
  *
- * export default class extends Model {
- *   @hasMany users;
- * }
+ * export default Model.extend({
+ *   @hasMany users: null
+ * });
  * ```
  *
  * @function
@@ -45,9 +45,9 @@ export const hasMany = decoratorWithKeyReflection(DS.hasMany);
  * import Model from 'ember-data/model';
  * import { belongsTo } from 'ember-decorators/data';
  *
- * export default class extends Model {
- *   @belongsTo user;
- * }
+ * export default Model.extend({
+ *   @belongsTo user: null
+ * });
  * ```
  * @function
  * @param {String} [type] - Type of the `belongsTo` relationship

--- a/addon/data/index.js
+++ b/addon/data/index.js
@@ -10,7 +10,7 @@ import { decoratorWithKeyReflection } from '../utils/decorator-macros';
  * import { attr } from 'ember-decorators/data';
  *
  * export default class extends Model {
- *   @attr firstName
+ *   @attr firstName;
  * }
  * ```
  *
@@ -29,7 +29,7 @@ export const attr = decoratorWithParams(function(target, key, desc, params) {
  * import { hasMany } from 'ember-decorators/data';
  *
  * export default class extends Model {
- *   @hasMany users
+ *   @hasMany users;
  * }
  * ```
  *
@@ -46,7 +46,7 @@ export const hasMany = decoratorWithKeyReflection(DS.hasMany);
  * import { belongsTo } from 'ember-decorators/data';
  *
  * export default class extends Model {
- *   @belongsTo user
+ *   @belongsTo user;
  * }
  * ```
  * @function

--- a/addon/data/index.js
+++ b/addon/data/index.js
@@ -6,12 +6,12 @@ import { decoratorWithKeyReflection } from '../utils/decorator-macros';
  * Decorator that turns the property into an Ember Data attribute
  *
  * ```javascript
- * import DS from 'ember-data';
+ * import Model from 'ember-data/model';
  * import { attr } from 'ember-decorators/data';
  *
- * export default DS.Model.extend({
+ * export default class extends Model {
  *   @attr firstName
- * });
+ * }
  * ```
  *
  * @function
@@ -25,12 +25,12 @@ export const attr = decoratorWithParams(function(target, key, desc, params) {
  * Decorator that turns the property into an Ember Data `hasMany` relationship
  *
  * ```javascript
- * import DS from 'ember-data';
+ * import Model from 'ember-data/model';
  * import { hasMany } from 'ember-decorators/data';
  *
- * export default DS.Model.extend({
+ * export default class extends Model {
  *   @hasMany users
- * });
+ * }
  * ```
  *
  * @function
@@ -42,12 +42,12 @@ export const hasMany = decoratorWithKeyReflection(DS.hasMany);
  * Decorator that turns the property into an Ember Data `belongsTo` relationship
  *
  * ```javascript
- * import DS from 'ember-data';
+ * import Model from 'ember-data/model';
  * import { belongsTo } from 'ember-decorators/data';
  *
- * export default DS.Model.extend({
+ * export default class extends Model {
  *   @belongsTo user
- * });
+ * }
  * ```
  * @function
  * @param {String} [type] - Type of the `belongsTo` relationship

--- a/addon/object/computed.js
+++ b/addon/object/computed.js
@@ -12,16 +12,16 @@ import {
  * the original property.
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
  * import { alias } from 'ember-decorators/object/computed';
  *
- * export default Ember.Component.extend({
+ * export default class extends Component {
  *   person: {
  *     first: 'Joe'
  *   },
  *
  *   @alias('person.first') firstName
- * });
+ * }
  * ```
  *
  * @function
@@ -36,16 +36,16 @@ export const alias = decoratedPropertyWithRequiredParams(Ember.computed.alias);
  * for the provided dependent properties.
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
  * import { and } from 'ember-decorators/object/computed';
  *
- * export default Ember.Component.extend({
+ * export default class extends Component {
  *   person: {
  *     first: 'Joe'
  *   },
  *
- *   @and('first', 'last') hasFullName // false
- * });
+ *   @and('person.{first,last}') hasFullName // false
+ * }
  * ```
  *
  * @function
@@ -60,14 +60,14 @@ export const and = decoratedPropertyWithRequiredParams(Ember.computed.and);
  * boolean value.
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
  * import { bool } from 'ember-decorators/object/computed';
  *
- * export default Ember.Component.extend({
+ * export default class extends Component {
  *   messageCount: 1,
  *
  *   @bool('messageCount') hasMessages // true
- * });
+ * }
  * ```
  *
  * @function
@@ -82,15 +82,15 @@ export const bool = decoratedPropertyWithRequiredParams(Ember.computed.bool);
  * dependent properties.
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
  * import { collect } from 'ember-decorators/object/computed';
  *
- * export default Ember.Component.extend({
+ * export default class extends Component {
  *   light: 'strobe',
  *   lens: '35mm prime',
  *
  *   @collect('light', 'lens') equipment // ['strobe', '35mm prime']
- * });
+ * }
  * ```
  *
  * @function
@@ -105,14 +105,15 @@ export const collect = decoratedPropertyWithRequiredParams(Ember.computed.collec
  * property is null, an empty string, empty array, or empty function.
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
+ * import { A } from '@ember/array';
  * import { empty } from 'ember-decorators/object/computed';
  *
- * export default Ember.Component.extend({
- *   items: Ember.A(['taco', 'burrito']),
+ * export default class extends Component {
+ *   items: A(['taco', 'burrito']),
  *
  *   @empty('items') isEmpty // false
- * });
+ * }
  * ```
  *
  * @function
@@ -126,14 +127,14 @@ export const empty = decoratedPropertyWithRequiredParams(Ember.computed.empty);
  * A computed property that returns true if the dependent properties are equal.
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
  * import { equal } from 'ember-decorators/object/computed';
  *
- * export default Ember.Component.extend({
+ * export default class extends Component {
  *   state: 'sleepy',
  *
  *   @equal('state', 'sleepy') napTime // true
- * });
+ * }
  *
  * @function
  * @param {String} dependentKey - Key for the property to check
@@ -147,11 +148,12 @@ export const equal = decoratedPropertyWithRequiredParams(Ember.computed.equal);
  * Filters the items in the array by the provided callback.
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
+ * import { A } from '@ember/array';
  * import { filter } from 'ember-decorators/object/computed';
  *
- * export default Ember.Component.extend({
- *   chores: Ember.A([
+ * export default class extends Component {
+ *   chores: A([
  *     { name: 'cook', done: true },
  *     { name: 'clean', done: true },
  *     { name: 'write more unit tests', done: false }
@@ -160,7 +162,7 @@ export const equal = decoratedPropertyWithRequiredParams(Ember.computed.equal);
  *   @filter('chores', function(chore, index, array) {
  *     return !chore.done;
  *   }) remainingChores // [{name: 'write more unit tests', done: false}]
- * });
+ * }
  * ```
  *
  * @function
@@ -175,18 +177,19 @@ export const filter = decoratedPropertyWithRequiredParams(Ember.computed.filter)
  * Filters the array by the property and value.
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
+ * import { A } from '@ember/array';
  * import { filterBy } from 'ember-decorators/object/computed';
  *
- * export default Ember.Component.extend({
- *   chores: Ember.A([
+ * export default class extends Component {
+ *   chores: A([
  *     { name: 'cook', done: true },
  *     { name: 'clean', done: true },
  *     { name: 'write more unit tests', done: false }
  *   ]),
  *
  *   @filterBy('chores', 'done', false) remainingChores // [{name: 'write more unit tests', done: false}]
- * });
+ * }
  * ```
  *
  * @function
@@ -203,14 +206,14 @@ export const filterBy = decoratedPropertyWithRequiredParams(Ember.computed.filte
  * is greater than the provided value.
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
  * import { gt } from 'ember-decorators/object/computed';
  *
- * export default Ember.Component.extend({
+ * export default class extends Component {
  *   totalCats: 11,
  *
  *   @gt('totalCats', 10) isCatParty // true
- * });
+ * }
  * ```
  *
  * @function
@@ -226,14 +229,14 @@ export const gt = decoratedPropertyWithRequiredParams(Ember.computed.gt);
  * is greater than or equal to the provided value.
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
  * import { gte } from 'ember-decorators/object/computed';
  *
- * export default Ember.Component.extend({
+ * export default class extends Component {
  *   totalPlayers: 14,
  *
  *   @gte('totalPlayers', 14) hasEnoughPlayers // true
- * });
+ * }
  * ```
  *
  * @function
@@ -249,15 +252,16 @@ export const gte = decoratedPropertyWithRequiredParams(Ember.computed.gte);
  * elements from two or more dependent arrays.
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
+ * import { A } from '@ember/array';
  * import { intersect } from 'ember-decorators/object/computed';
  *
- * export default Ember.Component.extend({
- *   likes: Ember.A([ 'tacos', 'puppies', 'pizza' ]),
- *   foods: Ember.A(['tacos', 'pizza']),
+ * export default class extends Component {
+ *   likes: A([ 'tacos', 'puppies', 'pizza' ]),
+ *   foods: A(['tacos', 'pizza']),
  *
  *   @intersect('likes', 'foods') favoriteFoods // ['tacos', 'pizza']
- * });
+ * }
  * ```
  *
  * @function
@@ -272,14 +276,14 @@ export const intersect = decoratedPropertyWithRequiredParams(Ember.computed.inte
  * is less than the provided value.
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
  * import { lt } from 'ember-decorators/object/computed';
  *
- * export default Ember.Component.extend({
+ * export default class extends Component {
  *   totalDogs: 3,
  *
  *   @lt('totalDogs', 10) isDogParty // true
- * });
+ * }
  * ```
  *
  * @function
@@ -295,14 +299,14 @@ export const lt = decoratedPropertyWithRequiredParams(Ember.computed.lt);
  * is less than or equal to the provided value.
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
  * import { lte } from 'ember-decorators/object/computed';
  *
- * export default Ember.Component.extend({
+ * export default class extends Component {
  *   totalPlayers: 14,
  *
  *   @lte('totalPlayers', 14) hasEnoughPlayers // true
- * });
+ * }
  * ```
  *
  * @function
@@ -317,16 +321,17 @@ export const lte = decoratedPropertyWithRequiredParams(Ember.computed.lte);
  * Returns an array mapped via the callback
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
+ * import { A } from '@ember/array';
  * import { map } from 'ember-decorators/object/computed';
  *
- * export default Ember.Component.extend({
- *   chores: Ember.A(['clean', 'write more unit tests']),
+ * export default class extends Component {
+ *   chores: A(['clean', 'write more unit tests']),
  *
  *   @map('chores', function(chore, index) {
  *     return chore.toUpperCase() + '!';
  *   }) loudChores // ['CLEAN!', 'WRITE MORE UNIT TESTS!']
- * });
+ * }
  * ```
  *
  * @function
@@ -341,18 +346,19 @@ export const map = decoratedPropertyWithRequiredParams(Ember.computed.map);
  * Returns an array mapped to the specified key.
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
+ * import { A } from '@ember/array';
  * import { mapBy } from 'ember-decorators/object/computed';
  *
- * export default Ember.Component.extend({
- *   people: Ember.A([
+ * export default class extends Component {
+ *   people: A([
  *     {name: "George", age: 5},
  *     {name: "Stella", age: 10},
  *     {name: "Violet", age: 7}
  *   ]),
  *
  *   @mapBy('people', 'age') ages // [5, 10, 7]
- * });
+ * }
  * ```
  *
  * @function
@@ -369,14 +375,14 @@ export const mapBy = decoratedPropertyWithRequiredParams(Ember.computed.mapBy);
  * the RegExp and `false` if it does not.
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
  * import { match } from 'ember-decorators/object/computed';
  *
- * export default Ember.Component.extend({
+ * export default class extends Component {
  *   email: 'tomster@emberjs.com',
  *
  *   @match('email', /^.+@.+\..+$/) validEmail
- * });
+ * }
  * ```
  *
  * @function
@@ -392,14 +398,15 @@ export const match = decoratedPropertyWithRequiredParams(Ember.computed.match);
  * array. This will return `-Infinity` when the dependent array is empty.
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
+ * import { A } from '@ember/array';
  * import { max } from 'ember-decorators/object/computed';
  *
- * export default Ember.Component.extend({
- *   values: Ember.A([1, 2, 5, 10]),
+ * export default class extends Component {
+ *   values: A([1, 2, 5, 10]),
  *
  *   @max('values') maxValue // 10
- * });
+ * }
  * ```
  *
  * @function
@@ -414,14 +421,15 @@ export const max = decoratedPropertyWithRequiredParams(Ember.computed.max);
  * array. This will return `Infinity` when the dependent array is empty.
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
+ * import { A } from '@ember/array';
  * import { min } from 'ember-decorators/object/computed';
  *
- * export default Ember.Component.extend({
- *   values: Ember.A([1, 2, 5, 10]),
+ * export default class extends Component {
+ *   values: A([1, 2, 5, 10]),
  *
  *   @min('values') minValue // 1
- * });
+ * }
  * ```
  *
  * @function
@@ -437,14 +445,14 @@ export const min = decoratedPropertyWithRequiredParams(Ember.computed.min);
  * of `==`, which can be technically confusing.
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
  * import { none } from 'ember-decorators/object/computed';
  *
- * export default Ember.Component.extend({
+ * export default class extends Component {
  *   firstName: null,
  *
  *   @none('firstName') isNameless // true until firstName is defined
- * });
+ * }
  * ```
  *
  * @function
@@ -459,14 +467,14 @@ export const none = decoratedPropertyWithRequiredParams(Ember.computed.none);
  * value for the dependent property.
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
  * import { not } from 'ember-decorators/object/computed';
  *
- * export default Ember.Component.extend({
+ * export default class extends Component {
  *   loggedIn: false,
  *
  *   @not('loggedIn') isAnonymous // true
- * });
+ * }
  * ```
  *
  * @function
@@ -481,14 +489,15 @@ export const not = decoratedPropertyWithRequiredParams(Ember.computed.not);
  * property is NOT null, an empty string, empty array, or empty function.
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
+ * import { A } from '@ember/array';
  * import { notEmpty } from 'ember-decorators/object/computed';
  *
- * export default Ember.Component.extend({
- *   groceryBag: Ember.A(['milk', 'eggs', 'apples']),
+ * export default class extends Component {
+ *   groceryBag: A(['milk', 'eggs', 'apples']),
  *
  *   @notEmpty('groceryBag') hasGroceriesToPutAway // true
- * });
+ * }
  * ```
  *
  * @function
@@ -506,14 +515,14 @@ export const notEmpty = decoratedPropertyWithRequiredParams(Ember.computed.notEm
  * diverge from the upstream property.
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
  * import { oneWay } from 'ember-decorators/object/computed';
  *
- * export default Ember.Component.extend({
+ * export default class extends Component {
  *   firstName: 'Joe',
  *
  *   @oneWay('firstName') originalName // will always be 'Joe'
- * });
+ * }
  * ```
  *
  * @function
@@ -528,15 +537,15 @@ export const oneWay = decoratedPropertyWithRequiredParams(Ember.computed.oneWay)
  * the provided dependent properties.
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
  * import { or } from 'ember-decorators/object/computed';
  *
- * export default Ember.Component.extend({
+ * export default class extends Component {
  *   hasJacket: true,
  *   hasUmbrella: false,
  *
  *   @or('hasJacket', 'hasUmbrella') isReadyForRain // true
- * });
+ * }
  * ```
  *
  * @function
@@ -551,12 +560,13 @@ export const or = decoratedPropertyWithRequiredParams(Ember.computed.or);
  * name is somewhat ambiguous as to which direction the data flows.
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
+ * import { A } from '@ember/array';
  * import { reads } from 'ember-decorators/object/computed';
  *
- * export default Ember.Component.extend({
+ * export default class extends Component {
  *   @reads('first') firstName
- * });
+ * }
  * ```
  *
  * @function
@@ -571,15 +581,16 @@ export const reads = decoratedPropertyWithRequiredParams(Ember.computed.reads);
  * the first dependent array that are not in the second dependent array.
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
+ * import { A } from '@ember/array';
  * import { setDiff } from 'ember-decorators/object/computed';
  *
- * export default Ember.Component.extend({
- *   likes: Ember.A([ 'tacos', 'puppies', 'pizza' ]),
- *   foods: Ember.A(['tacos', 'pizza']),
+ * export default class extends Component {
+ *   likes: A([ 'tacos', 'puppies', 'pizza' ]),
+ *   foods: A(['tacos', 'pizza']),
  *
  *   @setDiff('likes', 'foods') favoriteThingsThatArentFood // ['puppies']
- * });
+ * }
  * ```
  *
  * @function
@@ -613,11 +624,12 @@ export const setDiff = decoratedPropertyWithRequiredParams(Ember.computed.setDif
  * instead of series of `if`.
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
+ * import { A } from '@ember/array';
  * import { sort } from 'ember-decorators/object/computed';
  *
- * export default Ember.Component.extend({
- *   this.names = Ember.A([{name:'Link'},{name:'Zelda'},{name:'Ganon'},{name:'Navi'}]);
+ * export default class extends Component {
+ *   this.names = A([{name:'Link'},{name:'Zelda'},{name:'Ganon'},{name:'Navi'}]);
  *   @sort('names', function(a, b){
  *     if (a.name > b.name) {
  *       return 1;
@@ -627,7 +639,7 @@ export const setDiff = decoratedPropertyWithRequiredParams(Ember.computed.setDif
  *
  *     return 0;
  *   }) sortedNames // [{name:'Ganon'},{name:'Link'},{name:'Navi'},{name:'Zelda'}]
- * });
+ * }
  * ```
  *
  * @function
@@ -643,14 +655,15 @@ export const sort = decoratedPropertyWithRequiredParams(Ember.computed.sort);
  * array.
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
+ * import { A } from '@ember/array';
  * import { sum } from 'ember-decorators/object/computed';
  *
- * export default Ember.Component.extend({
- *   values: Ember.A([1, 2, 3]),
+ * export default class extends Component {
+ *   values: A([1, 2, 3]),
  *
  *   @sum('values') total // 6
- * });
+ * }
  * ```
  *
  * @function
@@ -664,15 +677,16 @@ export const sum = decoratedPropertyWithRequiredParams(Ember.computed.sum);
  * Alias for [union](http://emberjs.com/api/classes/Ember.computed.html#method_uniq).
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
+ * import { A } from '@ember/array';
  * import { union } from 'ember-decorators/object/computed';
  *
- * export default Ember.Component.extend({
- *   likes: Ember.A([ 'tacos', 'puppies', 'pizza' ]),
- *   foods: Ember.A(['tacos', 'pizza', 'ramen']),
+ * export default class extends Component {
+ *   likes: A([ 'tacos', 'puppies', 'pizza' ]),
+ *   foods: A(['tacos', 'pizza', 'ramen']),
  *
  *   @union('likes', 'foods') favorites // ['tacos', 'puppies', 'pizza', 'ramen']
- * });
+ * }
  * ```
  *
  * @function
@@ -686,15 +700,16 @@ export const union = decoratedPropertyWithRequiredParams(Ember.computed.union);
  * A computed property which returns a new array with all the unique elements from one or more dependent arrays.
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
+ * import { A } from '@ember/array';
  * import { uniq } from 'ember-decorators/object/computed';
  *
- * export default Ember.Component.extend({
- *   likes: Ember.A([ 'tacos', 'puppies', 'pizza' ]),
- *   foods: Ember.A(['tacos', 'pizza', 'ramen']),
+ * export default class extends Component {
+ *   likes: A([ 'tacos', 'puppies', 'pizza' ]),
+ *   foods: A(['tacos', 'pizza', 'ramen']),
  *
  *   @uniq('likes', 'foods') favorites // ['tacos', 'puppies', 'pizza', 'ramen']
- * });
+ * }
  * ```
  *
  * @function

--- a/addon/object/computed.js
+++ b/addon/object/computed.js
@@ -16,11 +16,11 @@ import {
  * import { alias } from 'ember-decorators/object/computed';
  *
  * export default class extends Component {
- *   person: {
+ *   person = {
  *     first: 'Joe'
- *   },
+ *   };
  *
- *   @alias('person.first') firstName
+ *   @alias('person.first') firstName;
  * }
  * ```
  *
@@ -40,11 +40,11 @@ export const alias = decoratedPropertyWithRequiredParams(Ember.computed.alias);
  * import { and } from 'ember-decorators/object/computed';
  *
  * export default class extends Component {
- *   person: {
+ *   person = {
  *     first: 'Joe'
- *   },
+ *   };
  *
- *   @and('person.{first,last}') hasFullName // false
+ *   @and('person.{first,last}') hasFullName; // false
  * }
  * ```
  *
@@ -64,9 +64,9 @@ export const and = decoratedPropertyWithRequiredParams(Ember.computed.and);
  * import { bool } from 'ember-decorators/object/computed';
  *
  * export default class extends Component {
- *   messageCount: 1,
+ *   messageCount = 1;
  *
- *   @bool('messageCount') hasMessages // true
+ *   @bool('messageCount') hasMessages; // true
  * }
  * ```
  *
@@ -86,10 +86,10 @@ export const bool = decoratedPropertyWithRequiredParams(Ember.computed.bool);
  * import { collect } from 'ember-decorators/object/computed';
  *
  * export default class extends Component {
- *   light: 'strobe',
- *   lens: '35mm prime',
+ *   light = 'strobe';
+ *   lens = '35mm prime';
  *
- *   @collect('light', 'lens') equipment // ['strobe', '35mm prime']
+ *   @collect('light', 'lens') equipment; // ['strobe', '35mm prime']
  * }
  * ```
  *
@@ -110,9 +110,9 @@ export const collect = decoratedPropertyWithRequiredParams(Ember.computed.collec
  * import { empty } from 'ember-decorators/object/computed';
  *
  * export default class extends Component {
- *   items: A(['taco', 'burrito']),
+ *   items = A(['taco', 'burrito']);
  *
- *   @empty('items') isEmpty // false
+ *   @empty('items') isEmpty; // false
  * }
  * ```
  *
@@ -131,9 +131,9 @@ export const empty = decoratedPropertyWithRequiredParams(Ember.computed.empty);
  * import { equal } from 'ember-decorators/object/computed';
  *
  * export default class extends Component {
- *   state: 'sleepy',
+ *   state = 'sleepy';
  *
- *   @equal('state', 'sleepy') napTime // true
+ *   @equal('state', 'sleepy') napTime; // true
  * }
  *
  * @function
@@ -153,15 +153,15 @@ export const equal = decoratedPropertyWithRequiredParams(Ember.computed.equal);
  * import { filter } from 'ember-decorators/object/computed';
  *
  * export default class extends Component {
- *   chores: A([
+ *   chores = A([
  *     { name: 'cook', done: true },
  *     { name: 'clean', done: true },
  *     { name: 'write more unit tests', done: false }
- *   ]),
+ *   ]);
  *
  *   @filter('chores', function(chore, index, array) {
  *     return !chore.done;
- *   }) remainingChores // [{name: 'write more unit tests', done: false}]
+ *   }) remainingChores; // [{name: 'write more unit tests', done: false}]
  * }
  * ```
  *
@@ -182,13 +182,13 @@ export const filter = decoratedPropertyWithRequiredParams(Ember.computed.filter)
  * import { filterBy } from 'ember-decorators/object/computed';
  *
  * export default class extends Component {
- *   chores: A([
+ *   chores = A([
  *     { name: 'cook', done: true },
  *     { name: 'clean', done: true },
  *     { name: 'write more unit tests', done: false }
- *   ]),
+ *   ]);
  *
- *   @filterBy('chores', 'done', false) remainingChores // [{name: 'write more unit tests', done: false}]
+ *   @filterBy('chores', 'done', false) remainingChores; // [{name: 'write more unit tests', done: false}]
  * }
  * ```
  *
@@ -210,9 +210,9 @@ export const filterBy = decoratedPropertyWithRequiredParams(Ember.computed.filte
  * import { gt } from 'ember-decorators/object/computed';
  *
  * export default class extends Component {
- *   totalCats: 11,
+ *   totalCats = 11;
  *
- *   @gt('totalCats', 10) isCatParty // true
+ *   @gt('totalCats', 10) isCatParty; // true
  * }
  * ```
  *
@@ -233,9 +233,9 @@ export const gt = decoratedPropertyWithRequiredParams(Ember.computed.gt);
  * import { gte } from 'ember-decorators/object/computed';
  *
  * export default class extends Component {
- *   totalPlayers: 14,
+ *   totalPlayers = 14;
  *
- *   @gte('totalPlayers', 14) hasEnoughPlayers // true
+ *   @gte('totalPlayers', 14) hasEnoughPlayers; // true
  * }
  * ```
  *
@@ -257,10 +257,10 @@ export const gte = decoratedPropertyWithRequiredParams(Ember.computed.gte);
  * import { intersect } from 'ember-decorators/object/computed';
  *
  * export default class extends Component {
- *   likes: A([ 'tacos', 'puppies', 'pizza' ]),
- *   foods: A(['tacos', 'pizza']),
+ *   likes = A([ 'tacos', 'puppies', 'pizza' ]);
+ *   foods = A(['tacos', 'pizza']);
  *
- *   @intersect('likes', 'foods') favoriteFoods // ['tacos', 'pizza']
+ *   @intersect('likes', 'foods') favoriteFoods; // ['tacos', 'pizza']
  * }
  * ```
  *
@@ -280,9 +280,9 @@ export const intersect = decoratedPropertyWithRequiredParams(Ember.computed.inte
  * import { lt } from 'ember-decorators/object/computed';
  *
  * export default class extends Component {
- *   totalDogs: 3,
+ *   totalDogs = 3;
  *
- *   @lt('totalDogs', 10) isDogParty // true
+ *   @lt('totalDogs', 10) isDogParty; // true
  * }
  * ```
  *
@@ -303,9 +303,9 @@ export const lt = decoratedPropertyWithRequiredParams(Ember.computed.lt);
  * import { lte } from 'ember-decorators/object/computed';
  *
  * export default class extends Component {
- *   totalPlayers: 14,
+ *   totalPlayers = 14;
  *
- *   @lte('totalPlayers', 14) hasEnoughPlayers // true
+ *   @lte('totalPlayers', 14) hasEnoughPlayers; // true
  * }
  * ```
  *
@@ -326,11 +326,11 @@ export const lte = decoratedPropertyWithRequiredParams(Ember.computed.lte);
  * import { map } from 'ember-decorators/object/computed';
  *
  * export default class extends Component {
- *   chores: A(['clean', 'write more unit tests']),
+ *   chores = A(['clean', 'write more unit tests']);
  *
  *   @map('chores', function(chore, index) {
  *     return chore.toUpperCase() + '!';
- *   }) loudChores // ['CLEAN!', 'WRITE MORE UNIT TESTS!']
+ *   }) loudChores; // ['CLEAN!', 'WRITE MORE UNIT TESTS!']
  * }
  * ```
  *
@@ -351,13 +351,13 @@ export const map = decoratedPropertyWithRequiredParams(Ember.computed.map);
  * import { mapBy } from 'ember-decorators/object/computed';
  *
  * export default class extends Component {
- *   people: A([
+ *   people = A([
  *     {name: "George", age: 5},
  *     {name: "Stella", age: 10},
  *     {name: "Violet", age: 7}
- *   ]),
+ *   ]);
  *
- *   @mapBy('people', 'age') ages // [5, 10, 7]
+ *   @mapBy('people', 'age') ages; // [5, 10, 7]
  * }
  * ```
  *
@@ -379,9 +379,9 @@ export const mapBy = decoratedPropertyWithRequiredParams(Ember.computed.mapBy);
  * import { match } from 'ember-decorators/object/computed';
  *
  * export default class extends Component {
- *   email: 'tomster@emberjs.com',
+ *   email = 'tomster@emberjs.com';
  *
- *   @match('email', /^.+@.+\..+$/) validEmail
+ *   @match('email', /^.+@.+\..+$/) validEmail;
  * }
  * ```
  *
@@ -403,9 +403,9 @@ export const match = decoratedPropertyWithRequiredParams(Ember.computed.match);
  * import { max } from 'ember-decorators/object/computed';
  *
  * export default class extends Component {
- *   values: A([1, 2, 5, 10]),
+ *   values = A([1, 2, 5, 10]);
  *
- *   @max('values') maxValue // 10
+ *   @max('values') maxValue; // 10
  * }
  * ```
  *
@@ -426,9 +426,9 @@ export const max = decoratedPropertyWithRequiredParams(Ember.computed.max);
  * import { min } from 'ember-decorators/object/computed';
  *
  * export default class extends Component {
- *   values: A([1, 2, 5, 10]),
+ *   values = A([1, 2, 5, 10]);
  *
- *   @min('values') minValue // 1
+ *   @min('values') minValue; // 1
  * }
  * ```
  *
@@ -449,9 +449,9 @@ export const min = decoratedPropertyWithRequiredParams(Ember.computed.min);
  * import { none } from 'ember-decorators/object/computed';
  *
  * export default class extends Component {
- *   firstName: null,
+ *   firstName = null;
  *
- *   @none('firstName') isNameless // true until firstName is defined
+ *   @none('firstName') isNameless; // true unless firstName is defined
  * }
  * ```
  *
@@ -471,9 +471,9 @@ export const none = decoratedPropertyWithRequiredParams(Ember.computed.none);
  * import { not } from 'ember-decorators/object/computed';
  *
  * export default class extends Component {
- *   loggedIn: false,
+ *   loggedIn = false;
  *
- *   @not('loggedIn') isAnonymous // true
+ *   @not('loggedIn') isAnonymous; // true
  * }
  * ```
  *
@@ -494,9 +494,9 @@ export const not = decoratedPropertyWithRequiredParams(Ember.computed.not);
  * import { notEmpty } from 'ember-decorators/object/computed';
  *
  * export default class extends Component {
- *   groceryBag: A(['milk', 'eggs', 'apples']),
+ *   groceryBag = A(['milk', 'eggs', 'apples']);
  *
- *   @notEmpty('groceryBag') hasGroceriesToPutAway // true
+ *   @notEmpty('groceryBag') hasGroceriesToPutAway; // true
  * }
  * ```
  *
@@ -519,9 +519,9 @@ export const notEmpty = decoratedPropertyWithRequiredParams(Ember.computed.notEm
  * import { oneWay } from 'ember-decorators/object/computed';
  *
  * export default class extends Component {
- *   firstName: 'Joe',
+ *   firstName = 'Joe';
  *
- *   @oneWay('firstName') originalName // will always be 'Joe'
+ *   @oneWay('firstName') originalName; // will always be 'Joe'
  * }
  * ```
  *
@@ -541,10 +541,10 @@ export const oneWay = decoratedPropertyWithRequiredParams(Ember.computed.oneWay)
  * import { or } from 'ember-decorators/object/computed';
  *
  * export default class extends Component {
- *   hasJacket: true,
- *   hasUmbrella: false,
+ *   hasJacket = true;
+ *   hasUmbrella = false;
  *
- *   @or('hasJacket', 'hasUmbrella') isReadyForRain // true
+ *   @or('hasJacket', 'hasUmbrella') isReadyForRain; // true
  * }
  * ```
  *
@@ -565,7 +565,9 @@ export const or = decoratedPropertyWithRequiredParams(Ember.computed.or);
  * import { reads } from 'ember-decorators/object/computed';
  *
  * export default class extends Component {
- *   @reads('first') firstName
+ *   first = 'Tomster';
+ *
+ *   @reads('first') firstName;
  * }
  * ```
  *
@@ -586,10 +588,10 @@ export const reads = decoratedPropertyWithRequiredParams(Ember.computed.reads);
  * import { setDiff } from 'ember-decorators/object/computed';
  *
  * export default class extends Component {
- *   likes: A([ 'tacos', 'puppies', 'pizza' ]),
- *   foods: A(['tacos', 'pizza']),
+ *   likes = A([ 'tacos', 'puppies', 'pizza' ]);
+ *   foods = A(['tacos', 'pizza']);
  *
- *   @setDiff('likes', 'foods') favoriteThingsThatArentFood // ['puppies']
+ *   @setDiff('likes', 'foods') favoriteThingsThatArentFood; // ['puppies']
  * }
  * ```
  *
@@ -629,7 +631,8 @@ export const setDiff = decoratedPropertyWithRequiredParams(Ember.computed.setDif
  * import { sort } from 'ember-decorators/object/computed';
  *
  * export default class extends Component {
- *   this.names = A([{name:'Link'},{name:'Zelda'},{name:'Ganon'},{name:'Navi'}]);
+ *   names = A([{name:'Link'},{name:'Zelda'},{name:'Ganon'},{name:'Navi'}]);
+ *
  *   @sort('names', function(a, b){
  *     if (a.name > b.name) {
  *       return 1;
@@ -638,7 +641,7 @@ export const setDiff = decoratedPropertyWithRequiredParams(Ember.computed.setDif
  *     }
  *
  *     return 0;
- *   }) sortedNames // [{name:'Ganon'},{name:'Link'},{name:'Navi'},{name:'Zelda'}]
+ *   }) sortedNames; // [{name:'Ganon'},{name:'Link'},{name:'Navi'},{name:'Zelda'}]
  * }
  * ```
  *
@@ -660,9 +663,9 @@ export const sort = decoratedPropertyWithRequiredParams(Ember.computed.sort);
  * import { sum } from 'ember-decorators/object/computed';
  *
  * export default class extends Component {
- *   values: A([1, 2, 3]),
+ *   values = A([1, 2, 3]);
  *
- *   @sum('values') total // 6
+ *   @sum('values') total; // 6
  * }
  * ```
  *
@@ -682,10 +685,10 @@ export const sum = decoratedPropertyWithRequiredParams(Ember.computed.sum);
  * import { union } from 'ember-decorators/object/computed';
  *
  * export default class extends Component {
- *   likes: A([ 'tacos', 'puppies', 'pizza' ]),
- *   foods: A(['tacos', 'pizza', 'ramen']),
+ *   likes = A([ 'tacos', 'puppies', 'pizza' ]);
+ *   foods = A(['tacos', 'pizza', 'ramen']);
  *
- *   @union('likes', 'foods') favorites // ['tacos', 'puppies', 'pizza', 'ramen']
+ *   @union('likes', 'foods') favorites; // ['tacos', 'puppies', 'pizza', 'ramen']
  * }
  * ```
  *
@@ -705,10 +708,10 @@ export const union = decoratedPropertyWithRequiredParams(Ember.computed.union);
  * import { uniq } from 'ember-decorators/object/computed';
  *
  * export default class extends Component {
- *   likes: A([ 'tacos', 'puppies', 'pizza' ]),
- *   foods: A(['tacos', 'pizza', 'ramen']),
+ *   likes = A([ 'tacos', 'puppies', 'pizza' ]);
+ *   foods = A(['tacos', 'pizza', 'ramen']);
  *
- *   @uniq('likes', 'foods') favorites // ['tacos', 'puppies', 'pizza', 'ramen']
+ *   @uniq('likes', 'foods') favorites; // ['tacos', 'puppies', 'pizza', 'ramen']
  * }
  * ```
  *

--- a/addon/object/computed.js
+++ b/addon/object/computed.js
@@ -15,7 +15,7 @@ import {
  * import Component from '@ember/component';
  * import { alias } from 'ember-decorators/object/computed';
  *
- * export default class extends Component {
+ * export default class UserProfileComponent extends Component {
  *   person = {
  *     first: 'Joe'
  *   };
@@ -39,7 +39,7 @@ export const alias = decoratedPropertyWithRequiredParams(Ember.computed.alias);
  * import Component from '@ember/component';
  * import { and } from 'ember-decorators/object/computed';
  *
- * export default class extends Component {
+ * export default class UserProfileComponent extends Component {
  *   person = {
  *     first: 'Joe'
  *   };
@@ -63,7 +63,7 @@ export const and = decoratedPropertyWithRequiredParams(Ember.computed.and);
  * import Component from '@ember/component';
  * import { bool } from 'ember-decorators/object/computed';
  *
- * export default class extends Component {
+ * export default class MessagesNotificationComponent extends Component {
  *   messageCount = 1;
  *
  *   @bool('messageCount') hasMessages; // true
@@ -85,7 +85,7 @@ export const bool = decoratedPropertyWithRequiredParams(Ember.computed.bool);
  * import Component from '@ember/component';
  * import { collect } from 'ember-decorators/object/computed';
  *
- * export default class extends Component {
+ * export default class CameraEquipmentComponent extends Component {
  *   light = 'strobe';
  *   lens = '35mm prime';
  *
@@ -109,7 +109,7 @@ export const collect = decoratedPropertyWithRequiredParams(Ember.computed.collec
  * import { A } from '@ember/array';
  * import { empty } from 'ember-decorators/object/computed';
  *
- * export default class extends Component {
+ * export default class FoodItemsComponent extends Component {
  *   items = A(['taco', 'burrito']);
  *
  *   @empty('items') isEmpty; // false
@@ -130,7 +130,7 @@ export const empty = decoratedPropertyWithRequiredParams(Ember.computed.empty);
  * import Component from '@ember/component';
  * import { equal } from 'ember-decorators/object/computed';
  *
- * export default class extends Component {
+ * export default class NapTimeComponent extends Component {
  *   state = 'sleepy';
  *
  *   @equal('state', 'sleepy') napTime; // true
@@ -152,7 +152,7 @@ export const equal = decoratedPropertyWithRequiredParams(Ember.computed.equal);
  * import { A } from '@ember/array';
  * import { filter } from 'ember-decorators/object/computed';
  *
- * export default class extends Component {
+ * export default class ChoresListComponent extends Component {
  *   chores = A([
  *     { name: 'cook', done: true },
  *     { name: 'clean', done: true },
@@ -181,7 +181,7 @@ export const filter = decoratedPropertyWithRequiredParams(Ember.computed.filter)
  * import { A } from '@ember/array';
  * import { filterBy } from 'ember-decorators/object/computed';
  *
- * export default class extends Component {
+ * export default class ChoresListComponent extends Component {
  *   chores = A([
  *     { name: 'cook', done: true },
  *     { name: 'clean', done: true },
@@ -209,7 +209,7 @@ export const filterBy = decoratedPropertyWithRequiredParams(Ember.computed.filte
  * import Component from '@ember/component';
  * import { gt } from 'ember-decorators/object/computed';
  *
- * export default class extends Component {
+ * export default class CatPartyComponent extends Component {
  *   totalCats = 11;
  *
  *   @gt('totalCats', 10) isCatParty; // true
@@ -232,7 +232,7 @@ export const gt = decoratedPropertyWithRequiredParams(Ember.computed.gt);
  * import Component from '@ember/component';
  * import { gte } from 'ember-decorators/object/computed';
  *
- * export default class extends Component {
+ * export default class PlayerListComponent extends Component {
  *   totalPlayers = 14;
  *
  *   @gte('totalPlayers', 14) hasEnoughPlayers; // true
@@ -256,7 +256,7 @@ export const gte = decoratedPropertyWithRequiredParams(Ember.computed.gte);
  * import { A } from '@ember/array';
  * import { intersect } from 'ember-decorators/object/computed';
  *
- * export default class extends Component {
+ * export default class FoodListComponent extends Component {
  *   likes = A([ 'tacos', 'puppies', 'pizza' ]);
  *   foods = A(['tacos', 'pizza']);
  *
@@ -279,7 +279,7 @@ export const intersect = decoratedPropertyWithRequiredParams(Ember.computed.inte
  * import Component from '@ember/component';
  * import { lt } from 'ember-decorators/object/computed';
  *
- * export default class extends Component {
+ * export default class DogPartyComponent extends Component {
  *   totalDogs = 3;
  *
  *   @lt('totalDogs', 10) isDogParty; // true
@@ -302,7 +302,7 @@ export const lt = decoratedPropertyWithRequiredParams(Ember.computed.lt);
  * import Component from '@ember/component';
  * import { lte } from 'ember-decorators/object/computed';
  *
- * export default class extends Component {
+ * export default class PlayerListComponent extends Component {
  *   totalPlayers = 14;
  *
  *   @lte('totalPlayers', 14) hasEnoughPlayers; // true
@@ -325,7 +325,7 @@ export const lte = decoratedPropertyWithRequiredParams(Ember.computed.lte);
  * import { A } from '@ember/array';
  * import { map } from 'ember-decorators/object/computed';
  *
- * export default class extends Component {
+ * export default class ChoresListComponent extends Component {
  *   chores = A(['clean', 'write more unit tests']);
  *
  *   @map('chores', function(chore, index) {
@@ -350,7 +350,7 @@ export const map = decoratedPropertyWithRequiredParams(Ember.computed.map);
  * import { A } from '@ember/array';
  * import { mapBy } from 'ember-decorators/object/computed';
  *
- * export default class extends Component {
+ * export default class PeopleListComponent extends Component {
  *   people = A([
  *     {name: "George", age: 5},
  *     {name: "Stella", age: 10},
@@ -378,7 +378,7 @@ export const mapBy = decoratedPropertyWithRequiredParams(Ember.computed.mapBy);
  * import Component from '@ember/component';
  * import { match } from 'ember-decorators/object/computed';
  *
- * export default class extends Component {
+ * export default class IsEmailValidComponent extends Component {
  *   email = 'tomster@emberjs.com';
  *
  *   @match('email', /^.+@.+\..+$/) validEmail;
@@ -402,7 +402,7 @@ export const match = decoratedPropertyWithRequiredParams(Ember.computed.match);
  * import { A } from '@ember/array';
  * import { max } from 'ember-decorators/object/computed';
  *
- * export default class extends Component {
+ * export default class MaxValueComponent extends Component {
  *   values = A([1, 2, 5, 10]);
  *
  *   @max('values') maxValue; // 10
@@ -425,7 +425,7 @@ export const max = decoratedPropertyWithRequiredParams(Ember.computed.max);
  * import { A } from '@ember/array';
  * import { min } from 'ember-decorators/object/computed';
  *
- * export default class extends Component {
+ * export default class MinValueComponent extends Component {
  *   values = A([1, 2, 5, 10]);
  *
  *   @min('values') minValue; // 1
@@ -448,7 +448,7 @@ export const min = decoratedPropertyWithRequiredParams(Ember.computed.min);
  * import Component from '@ember/component';
  * import { none } from 'ember-decorators/object/computed';
  *
- * export default class extends Component {
+ * export default class NameDisplayComponent extends Component {
  *   firstName = null;
  *
  *   @none('firstName') isNameless; // true unless firstName is defined
@@ -470,7 +470,7 @@ export const none = decoratedPropertyWithRequiredParams(Ember.computed.none);
  * import Component from '@ember/component';
  * import { not } from 'ember-decorators/object/computed';
  *
- * export default class extends Component {
+ * export default class UserInfoComponent extends Component {
  *   loggedIn = false;
  *
  *   @not('loggedIn') isAnonymous; // true
@@ -493,7 +493,7 @@ export const not = decoratedPropertyWithRequiredParams(Ember.computed.not);
  * import { A } from '@ember/array';
  * import { notEmpty } from 'ember-decorators/object/computed';
  *
- * export default class extends Component {
+ * export default class GroceryBagComponent extends Component {
  *   groceryBag = A(['milk', 'eggs', 'apples']);
  *
  *   @notEmpty('groceryBag') hasGroceriesToPutAway; // true
@@ -518,7 +518,7 @@ export const notEmpty = decoratedPropertyWithRequiredParams(Ember.computed.notEm
  * import Component from '@ember/component';
  * import { oneWay } from 'ember-decorators/object/computed';
  *
- * export default class extends Component {
+ * export default class UserProfileComponent extends Component {
  *   firstName = 'Joe';
  *
  *   @oneWay('firstName') originalName; // will always be 'Joe'
@@ -540,7 +540,7 @@ export const oneWay = decoratedPropertyWithRequiredParams(Ember.computed.oneWay)
  * import Component from '@ember/component';
  * import { or } from 'ember-decorators/object/computed';
  *
- * export default class extends Component {
+ * export default class OutfitFeaturesComponent extends Component {
  *   hasJacket = true;
  *   hasUmbrella = false;
  *
@@ -564,7 +564,7 @@ export const or = decoratedPropertyWithRequiredParams(Ember.computed.or);
  * import { A } from '@ember/array';
  * import { reads } from 'ember-decorators/object/computed';
  *
- * export default class extends Component {
+ * export default class UserProfileComponent extends Component {
  *   first = 'Tomster';
  *
  *   @reads('first') firstName;
@@ -587,7 +587,7 @@ export const reads = decoratedPropertyWithRequiredParams(Ember.computed.reads);
  * import { A } from '@ember/array';
  * import { setDiff } from 'ember-decorators/object/computed';
  *
- * export default class extends Component {
+ * export default class FavoriteThingsComponent extends Component {
  *   likes = A([ 'tacos', 'puppies', 'pizza' ]);
  *   foods = A(['tacos', 'pizza']);
  *
@@ -630,7 +630,7 @@ export const setDiff = decoratedPropertyWithRequiredParams(Ember.computed.setDif
  * import { A } from '@ember/array';
  * import { sort } from 'ember-decorators/object/computed';
  *
- * export default class extends Component {
+ * export default class SortNamesComponent extends Component {
  *   names = A([{name:'Link'},{name:'Zelda'},{name:'Ganon'},{name:'Navi'}]);
  *
  *   @sort('names', function(a, b){
@@ -662,7 +662,7 @@ export const sort = decoratedPropertyWithRequiredParams(Ember.computed.sort);
  * import { A } from '@ember/array';
  * import { sum } from 'ember-decorators/object/computed';
  *
- * export default class extends Component {
+ * export default class SumValuesComponent extends Component {
  *   values = A([1, 2, 3]);
  *
  *   @sum('values') total; // 6
@@ -684,7 +684,7 @@ export const sum = decoratedPropertyWithRequiredParams(Ember.computed.sum);
  * import { A } from '@ember/array';
  * import { union } from 'ember-decorators/object/computed';
  *
- * export default class extends Component {
+ * export default class LikesAndFoodsComponent extends Component {
  *   likes = A([ 'tacos', 'puppies', 'pizza' ]);
  *   foods = A(['tacos', 'pizza', 'ramen']);
  *
@@ -707,7 +707,7 @@ export const union = decoratedPropertyWithRequiredParams(Ember.computed.union);
  * import { A } from '@ember/array';
  * import { uniq } from 'ember-decorators/object/computed';
  *
- * export default class extends Component {
+ * export default class FavoriteThingsComponent extends Component {
  *   likes = A([ 'tacos', 'puppies', 'pizza' ]);
  *   foods = A(['tacos', 'pizza', 'ramen']);
  *

--- a/addon/object/evented.js
+++ b/addon/object/evented.js
@@ -14,7 +14,7 @@ import {
  * import Component from '@ember/component';
  * import { on } from 'ember-decorators/object/evented';
  *
- * export default class extends Component
+ * export default class EventDemoComponent extends Component
  *   @on('init')
  *   setupStuff() {
  *     //...
@@ -26,4 +26,3 @@ import {
  * @param {...String} eventNames - Names of the events that trigger the function
  */
 export const on = decoratorWithRequiredParams(Ember.on);
-

--- a/addon/object/evented.js
+++ b/addon/object/evented.js
@@ -11,15 +11,15 @@ import {
  * Triggers the target function on events
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
  * import { on } from 'ember-decorators/object/evented';
  *
- * export default Ember.Component.extend({
+ * export default class extends Component
  *   @on('init')
  *   setupStuff() {
  *     //...
  *   }
- * });
+ * }
  * ```
  *
  * @function

--- a/addon/object/index.js
+++ b/addon/object/index.js
@@ -76,18 +76,18 @@ export const action = decorator(function(target, key, desc) {
  * import computed from 'ember-decorators/object';
  *
  * export default class extends EmberObject {
- *   someKey: 'foo',
- *   otherKey: 'bar',
+ *   someKey = 'foo';
+ *   otherKey = 'bar';
  *
- *   person: {
+ *   person = {
  *     firstName: 'John',
  *     lastName: 'Smith'
- *   },
+ *   };
  *
  *   @computed('someKey', 'otherKey')
  *   foo(someKey, otherKey) {
  *     return `${someKey} - ${otherKey}`; // => 'foo - bar'
- *   },
+ *   }
  *
  *   @computed('person.{firstName,lastName}')
  *   fullName(firstName, lastName) {
@@ -124,11 +124,11 @@ export const action = decorator(function(target, key, desc) {
  * import computed from 'ember-decorators/object';
  *
  * export default class extends Component {
- *   first: 'John',
- *   last: 'Smith',
+ *   first = 'John';
+ *   last = 'Smith';
  *
  *   @computed('first', 'last')
- *   name: {
+ *   name = {
  *     get(first, last) {
  *       return `${first} ${last}`; // => 'John Smith'
  *     },
@@ -143,7 +143,7 @@ export const action = decorator(function(target, key, desc) {
  *
  *       return value;
  *     }
- *   }
+ *   };
  * }
  * ```
  *

--- a/addon/object/index.js
+++ b/addon/object/index.js
@@ -24,7 +24,7 @@ const { computed: emberComputed } = Ember;
  * import Component from '@ember/component';
  * import { action } from 'ember-decorators/object';
  *
- * export default class extends Component {
+ * export default class ActionDemoComponent extends Component {
  *   @action
  *   foo() {
  *     // do something
@@ -75,7 +75,7 @@ export const action = decorator(function(target, key, desc) {
  * import EmberObject from '@ember/object';
  * import computed from 'ember-decorators/object';
  *
- * export default class extends EmberObject {
+ * export default class User extends EmberObject {
  *   someKey = 'foo';
  *   otherKey = 'bar';
  *
@@ -107,7 +107,7 @@ export const action = decorator(function(target, key, desc) {
  * import EmberObject from '@ember/object';
  * import computed from 'ember-decorators/object';
  *
- * export default class extends EmberObject {
+ * export default class FooBar extends EmberObject {
  *   @computed
  *   foo() {
  *     // calculate stuff
@@ -123,7 +123,7 @@ export const action = decorator(function(target, key, desc) {
  * import { setProperties } from ''@ember/object';
  * import computed from 'ember-decorators/object';
  *
- * export default class extends Component {
+ * export default class UserProfileComponent extends Component {
  *   first = 'John';
  *   last = 'Smith';
  *

--- a/addon/object/index.js
+++ b/addon/object/index.js
@@ -23,21 +23,24 @@ const { computed: emberComputed } = Ember;
  * Before:
  *
  * ```js
- * export default Ember.Component.extend({
+ * import Component from '@ember/component';
+ *
+ * export default class extends Component {
  *   actions: {
  *     foo() {
  *       // do something
  *     }
  *   }
- * });
+ * }
  * ```
  *
  * After:
  *
  * ```js
+ * import Component from '@ember/component';
  * import { action } from 'ember-decorators/object';
  *
- * export default MyComponent extends Ember.Component {
+ * export default class extends Component {
  *   @action
  *   foo() {
  *     // do something
@@ -120,25 +123,25 @@ export const action = decorator(function(target, key, desc) {
  * #### "Real World"
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
  * import computed from 'ember-decorators/object';
  *
- * export default Ember.Component.extend({
+ * export default class extends Component {
  *   @computed('first', 'last')
  *   name(first, last) {
  *     return `${first} ${last}`;
  *   }
- * });
+ * }
  * ```
  *
  *
  * #### "Real World get/set syntax"
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
  * import computed from 'ember-decorators/object';
  *
- * export default Ember.Component.extend({
+ * export default class extends Component {
  *   @computed('first', 'last')
  *   name: {
  *     get(first, last) {
@@ -149,7 +152,7 @@ export const action = decorator(function(target, key, desc) {
  *       // ...
  *     }
  *   }
- * });
+ * }
  * ```
  *
  * @function
@@ -184,15 +187,15 @@ export const computed = decoratorWithParams(function(target, key, desc, params) 
  * Triggers the target function when the dependent properties have changed
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
  * import { observes } from 'ember-decorators/object';
  *
- * export default Ember.Component.extend({
+ * export default class extends Component {
  *   @observes('foo')
  *   bar() {
  *     //...
  *   }
- * });
+ * }
  * ```
  *
  * @function
@@ -206,16 +209,16 @@ export const observes = decoratorWithRequiredParams(Ember.observer);
  * Usage:
  *
  * ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
  * import { computed, readOnly } from 'ember-decorators/object';
  *
- * export default Ember.Component.extend({
+ * export default class extends Component {
  *   @readOnly
  *   @computed('first', 'last')
  *   name(first, last) {
  *     return `${first} ${last}`;
  *   }
- * });
+ * }
  * ```
  *
  * @function

--- a/addon/service/index.js
+++ b/addon/service/index.js
@@ -11,7 +11,7 @@ import { decoratorWithKeyReflection } from '../utils/decorator-macros';
  * import { service } from 'ember-decorators/service';
  *
  * export default class extends Component
- *   @service store
+ *   @service store;
  * }
  * ```
  *

--- a/addon/service/index.js
+++ b/addon/service/index.js
@@ -7,12 +7,12 @@ import { decoratorWithKeyReflection } from '../utils/decorator-macros';
  * Injects a service into the object as the decorated property
  *
  *  ```javascript
- * import Ember from 'ember';
+ * import Component from '@ember/component';
  * import { service } from 'ember-decorators/service';
  *
- * export default Ember.Component.extend({
+ * export default class extends Component
  *   @service store
- * });
+ * }
  * ```
  *
  * @function

--- a/addon/service/index.js
+++ b/addon/service/index.js
@@ -10,7 +10,7 @@ import { decoratorWithKeyReflection } from '../utils/decorator-macros';
  * import Component from '@ember/component';
  * import { service } from 'ember-decorators/service';
  *
- * export default class extends Component
+ * export default class StoreInjectedComponent extends Component
  *   @service store;
  * }
  * ```


### PR DESCRIPTION
Closes #120.
Closes #70, in that it only features ES6 class syntax or valid (`@attr prop: null`) EmberObject model syntax.