### PR TITLE
feat(object/computed): filter, map, sort: fallback to descriptor value for callback (#138)

### DIFF
--- a/addon/object/computed.js
+++ b/addon/object/computed.js
@@ -1,7 +1,8 @@
 import Ember from 'ember';
 
 import {
-  decoratedPropertyWithRequiredParams
+  decoratedPropertyWithRequiredParams,
+  decoratedPropertyWithOptionalCallback
 } from '../utils/decorator-macros';
 
 /**
@@ -167,7 +168,7 @@ export const equal = decoratedPropertyWithRequiredParams(Ember.computed.equal);
  * @param {String} dependentKey - Key for the array to filter
  * @param {Function(item: Any, index: Number, array: Array<Any>): Boolean} callback - The function to filter with
  */
-export const filter = decoratedPropertyWithRequiredParams(Ember.computed.filter);
+export const filter = decoratedPropertyWithOptionalCallback(Ember.computed.filter);
 
 /**
  * Decorator that wraps [Ember.computed.filterBy](http://emberjs.com/api/classes/Ember.computed.html#method_filterBy)
@@ -333,7 +334,7 @@ export const lte = decoratedPropertyWithRequiredParams(Ember.computed.lte);
  * @param {String} dependentKey - Key for the array to map over
  * @param {Function(item: Any, index: Number): Any} callback - Function to map over the array
  */
-export const map = decoratedPropertyWithRequiredParams(Ember.computed.map);
+export const map = decoratedPropertyWithOptionalCallback(Ember.computed.map);
 
 /**
  * Decorator that wraps [Ember.computed.mapBy](http://emberjs.com/api/classes/Ember.computed.html#method_mapBy)
@@ -634,7 +635,7 @@ export const setDiff = decoratedPropertyWithRequiredParams(Ember.computed.setDif
  * @param {String} dependentKey - The key for the array that should be sorted
  * @param {Array<String>|Function(Any, Any): Number} sortDefinition - Sorting function or sort descriptor
  */
-export const sort = decoratedPropertyWithRequiredParams(Ember.computed.sort);
+export const sort = decoratedPropertyWithOptionalCallback(Ember.computed.sort);
 
 /**
  * Decorator that wraps [Ember.computed.sum](http://emberjs.com/api/classes/Ember.computed.html#method_sum)

--- a/addon/object/computed.js
+++ b/addon/object/computed.js
@@ -158,6 +158,13 @@ export const equal = decoratedPropertyWithRequiredParams(Ember.computed.equal);
  *     { name: 'write more unit tests', done: false }
  *   ]),
  *
+ *   @filter('chores')
+ *   remainingChores(chore, index, array) {
+ *     return !chore.done;
+ *   }, // [{name: 'write more unit tests', done: false}]
+ *
+ *   // alternative syntax:
+ *
  *   @filter('chores', function(chore, index, array) {
  *     return !chore.done;
  *   }) remainingChores // [{name: 'write more unit tests', done: false}]
@@ -323,6 +330,13 @@ export const lte = decoratedPropertyWithRequiredParams(Ember.computed.lte);
  *
  * export default Ember.Component.extend({
  *   chores: Ember.A(['clean', 'write more unit tests']),
+ *
+ *   @map('chores')
+ *   loudChores(chore, index) {
+ *     return chore.toUpperCase() + '!';
+ *   }, // ['CLEAN!', 'WRITE MORE UNIT TESTS!']
+ *
+ *   // alternative syntax:
  *
  *   @map('chores', function(chore, index) {
  *     return chore.toUpperCase() + '!';
@@ -618,7 +632,21 @@ export const setDiff = decoratedPropertyWithRequiredParams(Ember.computed.setDif
  * import { sort } from 'ember-decorators/object/computed';
  *
  * export default Ember.Component.extend({
- *   this.names = Ember.A([{name:'Link'},{name:'Zelda'},{name:'Ganon'},{name:'Navi'}]);
+ *   names: Ember.A([{name:'Link'},{name:'Zelda'},{name:'Ganon'},{name:'Navi'}]),
+ *
+ *   @sort('names')
+ *   sortedNames(a, b){
+ *     if (a.name > b.name) {
+ *       return 1;
+ *     } else if (a.name < b.name) {
+ *       return -1;
+ *     }
+ *
+ *     return 0;
+ *   }, // [{name:'Ganon'},{name:'Link'},{name:'Navi'},{name:'Zelda'}]
+ *
+ *   // alternative syntax:
+ *
  *   @sort('names', function(a, b){
  *     if (a.name > b.name) {
  *       return 1;

--- a/addon/utils/decorator-macros.js
+++ b/addon/utils/decorator-macros.js
@@ -39,10 +39,8 @@ export function decoratedPropertyWithOptionalCallback(fn) {
     }
 
     const value = extractValue(desc);
-    if (typeof value === 'function') {
-      return fn(...params, value);
-    }
+    assert(`Cannot use '${fn.name}' on field '${key}' without a callback`, typeof value === 'function');
 
-    assert(`Cannot use '${fn.name}' on field '${key}' without a callback`, false);
+    return fn(...params, value);
   });
 }

--- a/addon/utils/decorator-macros.js
+++ b/addon/utils/decorator-macros.js
@@ -29,3 +29,20 @@ export function decoratedPropertyWithRequiredParams(fn) {
     return fn(...params);
   });
 }
+
+export function decoratedPropertyWithOptionalCallback(fn) {
+  return decoratorWithParams(function(target, key, desc, params) {
+    assert(`Cannot use '${fn.name}' on field '${key}' without parameters`, params.length !== 0);
+
+    if (typeof params[params.length - 1] === 'function') {
+      return fn(...params);
+    }
+
+    const value = extractValue(desc);
+    if (typeof value === 'function') {
+      return fn(...params, value);
+    }
+
+    assert(`Cannot use '${fn.name}' on field '${key}' without a callback`, false);
+  });
+}

--- a/tests/unit/macro-test.js
+++ b/tests/unit/macro-test.js
@@ -191,6 +191,26 @@ test('filter', function(assert) {
   assert.deepEqual(obj.get('validNames').mapBy('name'), ['b','z','a']);
 });
 
+test('filter (no callback, use descriptor value)', function(assert) {
+  var obj = Ember.Object.extend({
+    init() {
+      this._super(...arguments);
+      this.names = Ember.A([
+        {name:'b', valid: true},
+        {name:'z', valid: true},
+        {name:'a', valid: true},
+        {name:'foo', valid: false}
+      ]);
+    },
+    @filter('names')
+    validNames(item) {
+      return item.valid;
+    }
+  }).create();
+
+  assert.deepEqual(obj.get('validNames').mapBy('name'), ['b','z','a']);
+});
+
 test('filterBy', function(assert) {
   var obj = Ember.Object.extend({
     init() {
@@ -290,6 +310,21 @@ test('map', function(assert) {
     @map('names',  function(name) {
       return name.toUpperCase() + '!';
     }) loudNames: null
+  }).create();
+
+  assert.deepEqual(obj.get('loudNames').toArray(),['ONE!','TWO!','THREE!']);
+});
+
+test('map (no callback, use descriptor value)', function(assert) {
+  var obj = Ember.Object.extend({
+    init() {
+      this._super(...arguments);
+      this.names = Ember.A(['one','two','three']);
+    },
+    @map('names')
+    loudNames(name) {
+      return name.toUpperCase() + '!';
+    }
   }).create();
 
   assert.deepEqual(obj.get('loudNames').toArray(),['ONE!','TWO!','THREE!']);
@@ -494,6 +529,27 @@ test('sort', function(assert) {
       return 0;
     })
     sortedNames: null
+  }).create();
+
+  assert.deepEqual(obj.get('sortedNames').mapBy('name'), ['a','b','foo','z']);
+});
+
+test('sort (no callback, use descriptor value)', function(assert) {
+  var obj = Ember.Object.extend({
+    init() {
+      this._super(...arguments);
+      this.names = Ember.A([{name:'b'},{name:'z'},{name:'a'},{name:'foo'}]);
+    },
+    @sort('names')
+    sortedNames(a, b){
+      if (a.name > b.name) {
+        return 1;
+      } else if (a.name < b.name) {
+        return -1;
+      }
+
+      return 0;
+    }
   }).create();
 
   assert.deepEqual(obj.get('sortedNames').mapBy('name'), ['a','b','foo','z']);


### PR DESCRIPTION
Also adds the `decoratedPropertyWithOptionalCallback` decorator macro.
    
Closes #138.

Needs rebase, when #137 is merged, or the other way around.