### PR TITLE
feat(object/computed): add uniqBy

### DIFF
--- a/addon/object/computed.js
+++ b/addon/object/computed.js
@@ -1,10 +1,9 @@
 import Ember from 'ember';
+import { assert } from '@ember/debug';
 import {
   decoratedPropertyWithRequiredParams,
   decoratedPropertyWithOptionalCallback
 } from '../utils/decorator-macros';
-
-const { assert } = Ember;
 
 /**
  * Decorator that wraps [Ember.computed.alias](http://emberjs.com/api/classes/Ember.computed.html#method_alias)
@@ -784,4 +783,6 @@ export const uniq = decoratedPropertyWithRequiredParams(Ember.computed.uniq);
  */
 export const uniqBy = Ember.computed.uniqBy ?
   decoratedPropertyWithRequiredParams(Ember.computed.uniqBy) :
-  () => assert('uniqBy is only available from Ember.js v2.7 onwards.', false);
+  () => {
+    assert('uniqBy is only available from Ember.js v2.7 onwards.', false);
+  };

--- a/addon/object/computed.js
+++ b/addon/object/computed.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import { assert } from '@ember/debug';
 
 import {
   decoratedPropertyWithRequiredParams,
@@ -781,4 +782,6 @@ export const uniq = decoratedPropertyWithRequiredParams(Ember.computed.uniq);
  * @param {String} dependentKey - Key of the array to uniq
  * @param {String} propertyKey - Key of the property on the objects of the array to determine uniqueness by
  */
-export const uniqBy = decoratedPropertyWithRequiredParams(Ember.computed.uniqBy);
+export const uniqBy = Ember.computed.uniqBy ?
+  decoratedPropertyWithRequiredParams(Ember.computed.uniqBy) :
+  () => assert('uniqBy is only available from Ember.js v2.7 onwards.', false);

--- a/addon/object/computed.js
+++ b/addon/object/computed.js
@@ -1,10 +1,10 @@
 import Ember from 'ember';
-import { assert } from '@ember/debug';
-
 import {
   decoratedPropertyWithRequiredParams,
   decoratedPropertyWithOptionalCallback
 } from '../utils/decorator-macros';
+
+const { assert } = Ember;
 
 /**
  * Decorator that wraps [Ember.computed.alias](http://emberjs.com/api/classes/Ember.computed.html#method_alias)

--- a/addon/object/computed.js
+++ b/addon/object/computed.js
@@ -747,3 +747,38 @@ export const union = decoratedPropertyWithRequiredParams(Ember.computed.union);
  * @param {String} dependentKey - Key of the array to uniq
  */
 export const uniq = decoratedPropertyWithRequiredParams(Ember.computed.uniq);
+
+/**
+ * Decorator that wraps [Ember.computed.uniqBy](http://emberjs.com/api/classes/Ember.computed.html#method_uniqBy)
+ *
+ * A computed property which returns a new array with all the unique elements
+ * from an array, with uniqueness determined by a specific key.
+ *
+ * ```javascript
+ * import Component from '@ember/component';
+ * import { A } from '@ember/array';
+ * import { uniqBy } from 'ember-decorators/object/computed';
+ *
+ * export default class FruitBowlComponent extends Component {
+ *   fruits = A([
+ *     { name: 'banana', color: 'yellow' },
+ *     { name: 'apple',  color: 'red' },
+ *     { name: 'kiwi',   color: 'brown' },
+ *     { name: 'cherry', color: 'red' },
+ *     { name: 'lemon',  color: 'yellow' }
+ *   ]);
+ *
+ *   @uniqBy('fruits', 'color') oneOfEachColor;
+ *   // [
+ *   //  { name: 'banana', color: 'yellow'},
+ *   //  { name: 'apple',  color: 'red'},
+ *   //  { name: 'kiwi',   color: 'brown'}
+ *   // ]
+ * }
+ * ```
+ *
+ * @function
+ * @param {String} dependentKey - Key of the array to uniq
+ * @param {String} propertyKey - Key of the property on the objects of the array to determine uniqueness by
+ */
+export const uniqBy = decoratedPropertyWithRequiredParams(Ember.computed.uniqBy);

--- a/tests/unit/macro-test.js
+++ b/tests/unit/macro-test.js
@@ -33,6 +33,7 @@ import {
 } from 'ember-decorators/object/computed';
 import { readOnly } from 'ember-decorators/object';
 import { module, test } from 'qunit';
+import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 
 module('macro decorator');
 
@@ -595,30 +596,40 @@ test('uniq', function(assert) {
   assert.deepEqual(obj.get('uniqNames').toArray(),['one','two','three']);
 });
 
-test('uniqBy', function(assert) {
-  var obj = Ember.Object.extend({
-    init() {
-      this._super(...arguments);
-      this.fruits = Ember.A([
-        { name: 'banana', color: 'yellow' },
-        { name: 'apple',  color: 'red' },
-        { name: 'kiwi',   color: 'brown' },
-        { name: 'cherry', color: 'red' },
-        { name: 'lemon',  color: 'yellow' }
-      ]);
-    },
-    @uniqBy('fruits', 'color') oneOfEachColor: null
-  }).create();
+if (hasEmberVersion(2, 7)) {
+  test('uniqBy', function(assert) {
+    var obj = Ember.Object.extend({
+      init() {
+        this._super(...arguments);
+        this.fruits = Ember.A([
+          { name: 'banana', color: 'yellow' },
+          { name: 'apple',  color: 'red' },
+          { name: 'kiwi',   color: 'brown' },
+          { name: 'cherry', color: 'red' },
+          { name: 'lemon',  color: 'yellow' }
+        ]);
+      },
+      @uniqBy('fruits', 'color') oneOfEachColor: null
+    }).create();
 
-  assert.deepEqual(
-    obj.get('oneOfEachColor').toArray(),
-    [
-      { name: 'banana', color: 'yellow'},
-      { name: 'apple',  color: 'red'},
-      { name: 'kiwi',   color: 'brown'}
-    ]
-  );
-});
+    assert.deepEqual(
+      obj.get('oneOfEachColor').toArray(),
+      [
+        { name: 'banana', color: 'yellow'},
+        { name: 'apple',  color: 'red'},
+        { name: 'kiwi',   color: 'brown'}
+      ]
+    );
+  }, 'is available in Ember 2.7+ and works correctly');
+} else {
+  test('uniqBy', function(assert) {
+    assert.throws(() => {
+      Ember.Object.extend({
+        @uniqBy('fruits', 'color') oneOfEachColor: null
+      });
+    }, /Ember\.js v2\.7/, 'is not available in Ember <2.7 and throws an assertion');
+  });
+}
 
 test('macros cannot be used without parameters', function(assert) {
   assert.throws(

--- a/tests/unit/macro-test.js
+++ b/tests/unit/macro-test.js
@@ -28,7 +28,8 @@ import {
   sort,
   sum,
   union,
-  uniq
+  uniq,
+  uniqBy
 } from 'ember-decorators/object/computed';
 import { readOnly } from 'ember-decorators/object';
 import { module, test } from 'qunit';
@@ -592,6 +593,31 @@ test('uniq', function(assert) {
   }).create();
 
   assert.deepEqual(obj.get('uniqNames').toArray(),['one','two','three']);
+});
+
+test('uniqBy', function(assert) {
+  var obj = Ember.Object.extend({
+    init() {
+      this._super(...arguments);
+      this.fruits = Ember.A([
+        { name: 'banana', color: 'yellow' },
+        { name: 'apple',  color: 'red' },
+        { name: 'kiwi',   color: 'brown' },
+        { name: 'cherry', color: 'red' },
+        { name: 'lemon',  color: 'yellow' }
+      ]);
+    },
+    @uniqBy('fruits', 'color') oneOfEachColor: null
+  }).create();
+
+  assert.deepEqual(
+    obj.get('oneOfEachColor').toArray(),
+    [
+      { name: 'banana', color: 'yellow'},
+      { name: 'apple',  color: 'red'},
+      { name: 'kiwi',   color: 'brown'}
+    ]
+  );
 });
 
 test('macros cannot be used without parameters', function(assert) {


### PR DESCRIPTION
Docs: http://emberjs.com/api/classes/Ember.computed.html#method_uniqBy

Closes #71.

I guess this one must have fallen through the cracks. Together with #143 we have full feature parity with `Ember.computed`. :tada: :grinning: 